### PR TITLE
タイトルが長すぎるときにカット

### DIFF
--- a/src/components/postcard.tsx
+++ b/src/components/postcard.tsx
@@ -19,7 +19,7 @@ const PostCard = ({ post }: PostCardProps) => {
         </div>
       </div>
       <div className="px-2 py-4">
-        <h1 className="font-bold text-lg">{post.frontMatter.title}</h1>
+        <h1 className="font-bold text-lg truncate">{post.frontMatter.title}</h1>
         <span>{post.frontMatter.date}</span>
       </div>
     </Link>


### PR DESCRIPTION
記事一覧画面のタイトルが長すぎるときにtruncateしました。